### PR TITLE
'Show Table' action option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,22 @@
-# Timekeeper Readme
+# Timekeeper
 
-# Project
+- [Timekeeper](#timekeeper)
+  - [Project](#project)
+  - [Installation](#installation)
+    - [Dependencies](#dependencies)
+  - [Usage](#usage)
+    - [First Run](#first-run)
+    - [Options](#options)
+
+## Project
 
 This is a simple tool to keep track of the duration of regular activities, such as your workshift. It was built using mainly Python 3 and Pandas and has a quite simple usage.
 
-# Installation
+## Installation
 
 At least for now, the tool does not have an executable version that handles all the needed installations. So, you'll need to fullfill the dependencies manually.
 
-## Dependencies
+### Dependencies
 
 - Python 3
 - Python 3 libs:
@@ -19,9 +27,9 @@ At least for now, the tool does not have an executable version that handles all 
 
 After making sure the dependencies are satisfied, download the `timekeeper.py` file.
 
-# Usage
+## Usage
 
-## First Run
+### First Run
 
 To run Timekeeper, it is recommended to create a separate folder for the tool:
 
@@ -41,11 +49,11 @@ Now, you can record the beginning of your first activity:
 python timekeeper.py --begin 
 ```
 
-## Options
+### Options
 
 Timekeeper has some options to be executed with.
 
-### Action Options
+#### Action Options
 
 These options define the action the tool will execute and are mutually excludent. If none of those is passed, the script will prompt the user for input, allowing for `--begin` or `--end` behaviors.
 
@@ -57,9 +65,11 @@ These options define the action the tool will execute and are mutually excludent
 
 `--end`, `-e`: Edits the last line of the log with the current time as end time. If the previous entry already has an end time, a warning will be shown, asking for confirmation to proceed with the overwriting.
 
-`--stats`, `-s`: Displays stats for a specific period and for all the entries. By default, the period is current calendar month and this can be changed using the modifier `--period`.
+`--stats`, `-s`: Displays stats for a specific period and for all the entries. By default, the period is the current calendar month and this can be changed using the modifier `--period`.
 
-### Modifier options
+`--table`, `-t`: Displays the full table for a specific period and for all the entries. By default, the period is the current calendar month and this can be changed using the modifier `--period`.
+
+#### Modifier options
 
 These options aren't required and modify an action option.
 


### PR DESCRIPTION
Adds show table action option.

This option simply prints the .csv using `tabulate` library. The option can be executed by running:
```bash
# -t also works
python timekeeper.py --table
```
In the future, there could also be prettifying of the printed values, like formatting dates and allowing for ordering the table.